### PR TITLE
Fixed form matcher specs

### DIFF
--- a/lib/rspec/hanami/matchers/form_matchers.rb
+++ b/lib/rspec/hanami/matchers/form_matchers.rb
@@ -59,7 +59,7 @@ module RSpec
         description { "have field with params" }
         match do |form|
           @form = form
-          @params = ::Hanami::Utils::Hash.new(@params).symbolize!
+          @params = ::Hanami::Utils::Hash.new(params).symbolize!
           @form_data = RSpec::Hanami::FormParser.new.call(form.to_s)
 
           form_data.any? do |input|

--- a/spec/support/views.rb
+++ b/spec/support/views.rb
@@ -6,7 +6,7 @@ class MainView
   include Hanami::Helpers::FormHelper
 
   def params
-    Hanami::Action::Params.new({})
+    {}
   end
 
   def form


### PR DESCRIPTION
This fixes failing tests in master. Possibly related to #12 :wink: 
Rspec errors:
```
1) form matchers #have_field for form with invalid field return false
   Failure/Error: Hanami::Action::Params.new({})
   
   NoMethodError:
     undefined method `call' for nil:NilClass
     Did you mean?  caller
   # /home/user/.rvm/gems/ruby-2.3.1/gems/hanami-validations-1.0.0/lib/hanami/validations.rb:360:in `validate'
   # /home/user/.rvm/gems/ruby-2.3.1/gems/hanami-controller-1.0.1/lib/hanami/action/params.rb:72:in `initialize'
   # ./spec/support/views.rb:9:in `new'
   # ./spec/support/views.rb:9:in `params'
   # /home/user/.rvm/gems/ruby-2.3.1/gems/hanami-helpers-1.0.0/lib/hanami/helpers/form_helper/form_builder.rb:118:in `initialize'
   # /home/user/.rvm/gems/ruby-2.3.1/gems/hanami-helpers-1.0.0/lib/hanami/helpers/form_helper.rb:418:in `new'
   # /home/user/.rvm/gems/ruby-2.3.1/gems/hanami-helpers-1.0.0/lib/hanami/helpers/form_helper.rb:418:in `form_for'
   # ./spec/support/views.rb:13:in `form'
   # ./spec/rspec/hanami/matchers/form_matchers_spec.rb:64:in `block (4 levels) in <top (required)>'
```

Rspec command to reproduce:
```sh
rspec ./spec/rspec/hanami/matchers/form_matchers_spec.rb:63 # form matchers #have_field for form with invalid field return false
```