### PR TITLE
Fixed RequestHelpers::Request #env

### DIFF
--- a/lib/rspec/hanami/request_helpers.rb
+++ b/lib/rspec/hanami/request_helpers.rb
@@ -11,13 +11,13 @@ module RSpec
 
         def env
           default_env.tap do |env|
-            env['PATH_INFO']      = @path,
-            env['REQUEST_METHOD'] = @method,
+            env['PATH_INFO']      = @path
+            env['REQUEST_METHOD'] = @method
             env['QUERY_STRING']   = "?#{@query_string}"
             env['rack.input']     = StringIO.new(@params.to_json) if @params
 
             @headers.each do |key, value|
-              rack_name = key.upcase.tr('-', '_')
+              rack_name = key.to_s.upcase.tr('-', '_')
               env["HTTP_#{rack_name}"] = value
             end
           end

--- a/spec/rspec/hanami/request_spec.rb
+++ b/spec/rspec/hanami/request_spec.rb
@@ -11,8 +11,21 @@ RSpec.describe RSpec::Hanami::RequestHelpers::Request do
       it "returns hash for #{path} #{method}" do
         request = RSpec::Hanami::RequestHelpers::Request.new(method, path, options).env
         expect(request["REQUEST_METHOD"]).to eq method
-        expect(request["PATH_INFO"]).to eq  [path, method, "?"]
+        expect(request["PATH_INFO"]).to eq path
+        expect(request["QUERY_STRING"]).to eq "?"
       end
+    end
+
+    let(:headers) { { "Content-type": "application/json", "auth" => "whatever" } }
+    let(:params) { { "whatever": "whatever" } }
+
+    let(:options) { { headers: headers, params: params } }
+
+    it "returns hash for options" do
+      request = RSpec::Hanami::RequestHelpers::Request.new("GET", "", options).env
+      expect(request["HTTP_CONTENT_TYPE"]).to eq "application/json"
+      expect(request["HTTP_AUTH"]).to eq "whatever"
+      expect(request["rack.input"].string).to eq params.to_json
     end
   end
 end


### PR DESCRIPTION
Faced a some issue with `ENV['PATH_INFO']`.
`RequestHelpers::Request#env` method returned `["/", "GET", "?"]:Array` for `ENV['PATH_INFO']`.
Gives it to `Hanami#app`. And i'll get exception, when hanami initialize assets and check `path` for `start_with?` in hanami-1.2.0/lib/hanami/assets/asset.rb:35:
```ruby
Failures:

  1) Visit home
     Failure/Error: it { expect(get('/')).to be_success }

     NoMethodError:
       undefined method `start_with?' for ["/", "GET", "?"]:Array
     # /Users/ilia/.rvm/gems/ruby-2.3.5/gems/hanami-1.2.0/lib/hanami/assets/asset.rb:35:in `block in initialize'
     # /Users/ilia/.rvm/gems/ruby-2.3.5/gems/hanami-1.2.0/lib/hanami/assets/asset.rb:35:in `each'
     # /Users/ilia/.rvm/gems/ruby-2.3.5/gems/hanami-1.2.0/lib/hanami/assets/asset.rb:35:in `find'
     # /Users/ilia/.rvm/gems/ruby-2.3.5/gems/hanami-1.2.0/lib/hanami/assets/asset.rb:35:in `initialize'
     # /Users/ilia/.rvm/gems/ruby-2.3.5/gems/hanami-1.2.0/lib/hanami/assets/static.rb:43:in `new'
     # /Users/ilia/.rvm/gems/ruby-2.3.5/gems/hanami-1.2.0/lib/hanami/assets/static.rb:43:in `call'
     # /Users/ilia/.rvm/gems/ruby-2.3.5/gems/rack-2.0.5/lib/rack/content_length.rb:15:in `call'
     # /Users/ilia/.rvm/gems/ruby-2.3.5/gems/hanami-1.2.0/lib/hanami/app.rb:44:in `call'
     # /Users/ilia/.rvm/gems/ruby-2.3.5/gems/rspec-hanami-0.3.0/lib/rspec/hanami/request_helpers.rb:50:in `request'
     # /Users/ilia/.rvm/gems/ruby-2.3.5/gems/rspec-hanami-0.3.0/lib/rspec/hanami/request_helpers.rb:54:in `get'
     # ./spec/web/features/visit_home_spec.rb:4:in `block (2 levels) in <top (required)>'

Finished in 0.01475 seconds (files took 1.58 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/web/features/visit_home_spec.rb:4 # Visit home
```
Fixed by commas removed.