### PR TITLE
Add entity schema matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ Passes if form object has a field with wanted params
 expect(view.form).to have_field(node: input, type: 'text', id: 'user-first-name')
 ```
 
+### Entity specs
+Passes if argument type has a matching with type.
+You can use `Hanami::Entity::Types` for compare.
+
+#### `have_attribute`
+Passes if `:name` has `Types::String` type:
+
+``` ruby
+it { expect(User).to have_attribute(:name, Types::String) }
+```
+
+#### `have_attributes`
+Passes if `:name` has `Types::String` type and `:age` has `Types::Int` type:
+
+``` ruby
+it { expect(User).to have_attributes(name: Types::String, age: Types::Int) }
+```
+
 ## Also see
 
 * <https://github.com/rspec/rspec>

--- a/lib/rspec/hanami/match_type.rb
+++ b/lib/rspec/hanami/match_type.rb
@@ -1,0 +1,32 @@
+module RSpec
+  module Hanami
+    class MatchType
+      attr_reader :actual, :expected
+
+      def initialize(actual, expected)
+        @actual = actual
+        @expected = expected
+      end
+
+      def call
+        match_types?
+      end
+
+      private
+
+      def match_types?
+        return match_if_sum? if expected.class == Dry::Types::Sum
+
+        actual.is_a?(expected.primitive)
+      end
+
+      def match_if_sum?
+        expected.primitive?(actual)
+      end
+    end
+  end
+end
+
+# Syntactic shortcut to reference Hanami::Entity::Types in custom matchers
+#
+Types = ::Hanami::Entity::Types

--- a/lib/rspec/hanami/matchers.rb
+++ b/lib/rspec/hanami/matchers.rb
@@ -2,11 +2,13 @@ require 'rspec/core/warnings'
 require 'rspec/expectations'
 require 'rspec/hanami/form_parser'
 require 'rspec/hanami/match_status'
+require 'rspec/hanami/match_type'
 require 'rspec/hanami/matchers/have_http_status'
 require 'rspec/hanami/matchers/match_in_body'
 require 'rspec/hanami/matchers/be_status'
 require 'rspec/hanami/matchers/form_matchers'
 require 'rspec/hanami/matchers/redirect_to'
+require 'rspec/hanami/matchers/match_entity_schema'
 
 module RSpec
   module Hanami

--- a/lib/rspec/hanami/matchers/match_entity_schema.rb
+++ b/lib/rspec/hanami/matchers/match_entity_schema.rb
@@ -1,0 +1,78 @@
+module RSpec
+  module Hanami
+    module Matchers
+      extend ::RSpec::Matchers::DSL
+
+      # @api public
+      # Passes if `parameter` has an passed attribute of expected type
+      # Hanami::Entity::Types are allowed
+      #
+      # expect(User).to have_attribute(:name, Type::String)
+      #
+      matcher :have_attribute do |parameter, type|
+        attr_reader :expected_type
+
+        description { "have #{expected_type.name} type" }
+        match do |object|
+          @attributes = object.instance_variable_get(:@attributes)
+          @actual = @attributes[parameter]
+          @expected_type = type
+
+          RSpec::Hanami::MatchType.new(actual, expected_type).call
+        end
+
+        failure_message do |actual|
+          "expected that #{actual.class} should match with #{expected_type.name}"\
+          "\nDiff: #{differ.diff_as_string(actual.class.to_s, expected_type.name)}"
+        end
+
+        failure_message_when_negated do |actual|
+          "expected that #{actual.class} should not match with #{expected_type.name}"
+        end
+
+        def differ
+          RSpec::Support::Differ.new(
+            color: RSpec::Matchers.configuration.color?
+          )
+        end
+      end
+
+      # @api public
+      # Passes if all `parameters` has an passed attribute of expected types.
+      # Hanami::Entity::Types are allowed
+      #
+      # expect(User).to have_attributes(name: Type::String, ...)
+      #
+      matcher :have_attributes do |**parameters|
+        attr_reader :attributes, :actual_types, :expected_types
+
+        description { "have #{expected_types} types" }
+        match do |object|
+          @attributes = object.instance_variable_get(:@attributes)
+          @actual_types = attributes.map { |_attr, type| type.class }.join(', ')
+          @expected_types = parameters.map { |_attr, type| type.name }.join(', ')
+
+          parameters.all? do |attribute, type|
+            actual = attributes[attribute]
+            RSpec::Hanami::MatchType.new(actual, type).call
+          end
+        end
+
+        failure_message do |_actual|
+          "expected that #{actual_types} should match with #{expected_types}"\
+          "\nDiff: #{differ.diff_as_string(actual_types, expected_types)}"
+        end
+
+        failure_message_when_negated do |_actual|
+          "expected that #{actual_types} should not match with #{expected_types}"
+        end
+
+        def differ
+          RSpec::Support::Differ.new(
+            color: RSpec::Matchers.configuration.color?
+          )
+        end
+      end
+    end
+  end
+end

--- a/rspec-hanami.gemspec
+++ b/rspec-hanami.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rspec"
   spec.add_dependency "hanami"
+  spec.add_dependency "hanami-model"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/rspec/hanami/matchers/match_entity_schema_spec.rb
+++ b/spec/rspec/hanami/matchers/match_entity_schema_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'rspec/hanami/matchers'
+
+RSpec.describe 'match_entity_schema' do
+  include RSpec::Hanami::Matchers
+
+  let(:entity) { UserEntity.new(id: 1, name: 'whatever', gender: true) }
+
+  describe 'pass with success' do
+    context 'for UserEntity single parameter' do
+      it { expect(entity).to have_attribute(:name, Types::String) }
+    end
+
+    context 'for UserEntity multiple parameters' do
+      it { expect(entity).to have_attributes(id: Types::Int, name: Types::String, gender: Types::Bool) }
+    end
+  end
+
+  describe 'pass with failure' do
+    context 'for UserEntity single parameter' do
+      it { expect(entity).not_to have_attribute(:name, Types::Int) }
+    end
+
+    context 'for UserEntity multiple parameters' do
+      it { expect(entity).not_to have_attributes(id: Types::Int, name: Types::Int,  gender: Types::Bool) }
+    end
+  end
+end

--- a/spec/support/entities.rb
+++ b/spec/support/entities.rb
@@ -1,0 +1,9 @@
+require 'hanami/model'
+
+class UserEntity < Hanami::Entity
+  attributes do
+    attribute :id,     Types::Int
+    attribute :name,   Types::String
+    attribute :gender, Types::Bool
+  end
+end


### PR DESCRIPTION
#11 **Entity specs**
Passes if argument type has a matching with `Hanami::Entity::Types`.
For using this matchers, you can call `have_attribute` for single argument or `have_attributes` for multiple arguments:
```ruby
it { expect(User).to have_attribute(:name, Types::String) }
it { expect(User).to have_attributes(name: Types::String, ...) }
```
Better differable output:
![differ](http://joxi.net/zANzYQYCBxVZLA.jpg)