### PR TITLE
Content-Type header fix for RequestHelpers

### DIFF
--- a/lib/rspec/hanami/request_helpers.rb
+++ b/lib/rspec/hanami/request_helpers.rb
@@ -20,6 +20,9 @@ module RSpec
               rack_name = key.to_s.upcase.tr('-', '_')
               env["HTTP_#{rack_name}"] = value
             end
+            if env.key?("HTTP_CONTENT_TYPE")
+              env["CONTENT_TYPE"] = env.delete("HTTP_CONTENT_TYPE")
+            end
           end
         end
 

--- a/spec/rspec/hanami/request_spec.rb
+++ b/spec/rspec/hanami/request_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe RSpec::Hanami::RequestHelpers::Request do
 
     it "returns hash for options" do
       request = RSpec::Hanami::RequestHelpers::Request.new("GET", "", options).env
-      expect(request["HTTP_CONTENT_TYPE"]).to eq "application/json"
+      expect(request["CONTENT_TYPE"]).to eq "application/json"
+      expect(request["HTTP_CONTENT_TYPE"]).to be_nil
       expect(request["HTTP_AUTH"]).to eq "whatever"
       expect(request["rack.input"].string).to eq params.to_json
     end


### PR DESCRIPTION
I'm trying to write some requests specs using RSpec::Hanami::RequestHelpers and found unexpected behavior: Hanami application recognize passed parameters incorrectly.

Here is the code:

```Ruby
post "/any", params: { some: :params }, headers: { "Content-Type" => "application/json" }
```

Current source code is changes `Content-Type` to `HTTP_CONTENT_TYPE` and pass ENV-data to Rack application. Rack application expects content-type to be presented in CONTENT_TYPE header, so it cant's correctly process passed parameters. 

Here is my fix