### PR TITLE
include_json matcher compares data as hashes, not as json-strings

### DIFF
--- a/lib/rspec/hanami/matchers/include_json.rb
+++ b/lib/rspec/hanami/matchers/include_json.rb
@@ -21,8 +21,8 @@ module RSpec
 
         match do |object|
           @object = object
-          @actual = object.last.last
-          actual == JSON.generate(json_object)
+          @actual = JSON.parse(object.last.last, symbolize_names: true)
+          actual == json_object
         end
 
         failure_message { |actual| "expect #{object} to include #{json_object} json" }


### PR DESCRIPTION
I thought that it would better to see `include_json` diff in hashes, not in JSON-strings