### PR TITLE
Added "request" specs type

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,12 @@ Or install it yourself as:
 
     $ gem install rspec-hanami
 
-After that require gem to `spec_helper.rb` and include matchers to rspec:
+After that set the spec-type in your files for request specs:
 
 ```ruby
-require 'rspec/hanami'
+require 'spec_helper'
 
-RSpec.configure do |config|
-  config.include RSpec::Hanami::Matchers
-
+describe "GET /any/path", type: :request do
   # ...
 end
 ```

--- a/lib/rspec/hanami.rb
+++ b/lib/rspec/hanami.rb
@@ -1,8 +1,8 @@
 require 'rspec/hanami/version'
 require 'rspec/hanami/request_helpers'
+require 'rspec/hanami/matchers'
 
-module RSpec
-  module Hanami
-    autoload :Matchers, 'rspec/hanami/matchers'
-  end
+RSpec.configure do |config|
+  config.include RSpec::Hanami::Matchers, type: :request
+  config.include RSpec::Hanami::RequestHelpers, type: :request
 end

--- a/spec/rspec/hanami/matchers/be_status_spec.rb
+++ b/spec/rspec/hanami/matchers/be_status_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
-require 'rspec/hanami/matchers'
 
-RSpec.describe "be matchers" do
-  include RSpec::Hanami::Matchers
-
+RSpec.describe "be matchers", type: :request do
   let(:params) { {} }
 
   describe '#be_success' do

--- a/spec/rspec/hanami/matchers/form_matchers_spec.rb
+++ b/spec/rspec/hanami/matchers/form_matchers_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
-require 'rspec/hanami/matchers'
 
-RSpec.describe 'form matchers' do
-  include RSpec::Hanami::Matchers
-
+RSpec.describe 'form matchers', type: :request do
   let(:view) { MainView.new }
 
   describe '#have_action' do

--- a/spec/rspec/hanami/matchers/have_http_status_spec.rb
+++ b/spec/rspec/hanami/matchers/have_http_status_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
-require 'rspec/hanami/matchers'
 
-RSpec.describe "have_http_status" do
-  include RSpec::Hanami::Matchers
-
+RSpec.describe "have_http_status", type: :request do
   let(:params) { {} }
 
   describe 'with a successful number status' do

--- a/spec/rspec/hanami/matchers/include_json_spec.rb
+++ b/spec/rspec/hanami/matchers/include_json_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
-require 'rspec/hanami/matchers'
 
-RSpec.describe "include_json" do
-  include RSpec::Hanami::Matchers
-
+RSpec.describe "include_json", type: :request do
   let(:params) { {} }
 
   context 'for JsonAction' do

--- a/spec/rspec/hanami/matchers/match_entity_schema_spec.rb
+++ b/spec/rspec/hanami/matchers/match_entity_schema_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
-require 'rspec/hanami/matchers'
 
-RSpec.describe 'match_entity_schema' do
-  include RSpec::Hanami::Matchers
-
+RSpec.describe 'match_entity_schema', type: :request do
   let(:entity) { UserEntity.new(id: 1, name: 'whatever', gender: true) }
 
   describe 'pass with success' do

--- a/spec/rspec/hanami/matchers/match_in_body_spec.rb
+++ b/spec/rspec/hanami/matchers/match_in_body_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
-require 'rspec/hanami/matchers'
 
-RSpec.describe 'match_in_body' do
-  include RSpec::Hanami::Matchers
-
+RSpec.describe 'match_in_body', type: :request do
   let(:params) { {} }
 
   context 'for SuccessfulAction' do

--- a/spec/rspec/hanami/matchers/redirect_to_spec.rb
+++ b/spec/rspec/hanami/matchers/redirect_to_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
-require 'rspec/hanami/matchers'
 
-RSpec.describe "be matchers" do
-  include RSpec::Hanami::Matchers
-
+RSpec.describe "be matchers", type: :request do
   let(:params) { {} }
   let(:site)   { 'http://example.com/' }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 require 'coveralls'
 Coveralls.wear!
 
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
+
 # $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rspec/hanami'
 require 'rspec/support/spec'
-
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}


### PR DESCRIPTION
Including gem functionality by specifying `type: :request` in rspec's `describe` block
#14 