### PR TITLE
gemspec: updated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 **rspec-hanami** is a testing framework for [hanami](http://hanamirb.org)
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -34,6 +35,7 @@ end
 ```
 
 ### Capybara
+
 Check your `spec/features_helper.rb` and `spec/support/Capybara.rb` files. If you find something like this:
 
 ```ruby
@@ -43,6 +45,7 @@ Capybara.app = Hanami::App.new
 ```
 
 Please change this line to:
+
 ```ruby
 Capybara.app = ::Hanami::Container.new
 # or
@@ -52,7 +55,9 @@ Capybara.app = ::Hanami::App.new
 For more information see [this issue](https://github.com/davydovanton/rspec-hanami/issues/1)
 
 ## Supported matchers
+
 ### Request helpers
+
 You can use familiar request helpers like `#get`, `#post`, etc.
 These methods make full hanami app request and return env (array with 3 elements).
 
@@ -63,23 +68,27 @@ config.include RSpec::Hanami::RequestHelpers
 ```
 
 After that you can call any method:
+
 ```ruby
 it { expect(get('/')).to be_success }
 it { expect(post('/tasks')).to redirect_to('/tasks') }
 ```
 
 ### Controller Specs
+
 #### `have_http_status`
+
 Passes if `response` has a matching HTTP status code.
 
 The following symbolic status codes are allowed:
-  - `:error`
-  - `:missing`
-  - `:redirect`
-  - `:success`
-  - `Rack::Utils::SYMBOL_TO_STATUS_CODE`
 
-``` ruby
+- `:error`
+- `:missing`
+- `:redirect`
+- `:success`
+- `Rack::Utils::SYMBOL_TO_STATUS_CODE`
+
+```ruby
 response = action.call(params)
 expect(response).to have_http_status(404)
 expect(response).to have_http_status(:created)
@@ -90,88 +99,103 @@ expect(response).to have_http_status(:redirect)
 ```
 
 #### `be_success`
+
 Passes if `response` has a not 4xx and 5xx error code.
 
-``` ruby
+```ruby
 response = action.call(params)
 expect(response).to be_success
-````
+```
 
 #### `redirect_to`
+
 Passes if `response` has a redirect to special url
 
-``` ruby
+```ruby
 response = action.call(params)
 expect(response).to redirect_to('site.com')
 ```
 
 #### `match_in_body`
+
 Passes if `body` matches with argument
 
-``` ruby
+```ruby
 response = action.call(params)
 expect(response).to match_in_body('Tittle')
 expect(response).to match_in_body(/Tittle\s\d+/)
 ```
 
 #### `include_json`
+
 Passes if `json` string in the body matches with hash arg
 
-``` ruby
+```ruby
 response = action.call(params)
 expect(response).to include_json(name: 'Anton')
 expect(response).to include_json(user: { name: 'Anton })
 ```
 
 ### Views Specs
+
 #### `have_form_action`
+
 Passes if form object has an action
 
-``` ruby
+```ruby
 expect(view.form).to     have_form_action('/users')
 expect(view.form).to_not have_form_action('/books')
 ```
 
 #### `have_method`
+
 Passes if form object has a method
 
-``` ruby
+```ruby
 expect(view.form).to     have_method('POST')
 expect(view.form).to     have_method(:post)
 expect(view.form).to_not have_method(:put)
 ```
 
 #### `have_form_field`
+
 Passes if form object has a field with wanted params
 
-``` ruby
+```ruby
 expect(view.form).to have_form_field(node: 'input', type: 'text', id: 'user-first-name')
 ```
 
 ### Entity specs
+
 Passes if argument type has a matching with type.
 You can use `Hanami::Entity::Types` for compare.
 
+```ruby
+Types = ::Hanami::Entity::Types
+```
+
 #### `have_attribute`
+
 Passes if `:name` has `Types::String` type:
 
-``` ruby
+```ruby
 it { expect(User).to have_attribute(:name, Types::String) }
 ```
 
 #### `have_attributes`
+
 Passes if `:name` has `Types::String` type and `:age` has `Types::Int` type:
 
-``` ruby
+```ruby
 it { expect(User).to have_attributes(name: Types::String, age: Types::Int) }
 ```
 
 ## Also see
 
-* <https://github.com/rspec/rspec>
-* <https://github.com/rspec/rspec-core>
-* <https://github.com/rspec/rspec-expectations>
-* <https://github.com/rspec/rspec-mocks>
+- <https://github.com/rspec/rspec>
+- <https://github.com/rspec/rspec-core>
+- <https://github.com/rspec/rspec-expectations>
+- <https://github.com/rspec/rspec-mocks>
 
 ## Feature Requests & Bugs
 

--- a/lib/rspec/hanami/match_type.rb
+++ b/lib/rspec/hanami/match_type.rb
@@ -26,7 +26,3 @@ module RSpec
     end
   end
 end
-
-# Syntactic shortcut to reference Hanami::Entity::Types in custom matchers
-#
-Types = ::Hanami::Entity::Types

--- a/rspec-hanami.gemspec
+++ b/rspec-hanami.gemspec
@@ -20,10 +20,13 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rspec"
-  spec.add_dependency "hanami", "~> 1.0"
-  spec.add_dependency "hanami-model"
+  spec.add_dependency "hanami-utils", "~> 1.0"
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", ">= 1.6", "< 3"
+  spec.add_development_dependency "hanami-model", "~> 1.0"
+  spec.add_development_dependency "hanami-controller", "~> 1.0"
+  spec.add_development_dependency "hanami-helpers", "~> 1.0"
+  spec.add_development_dependency "hanami-view", "~> 1.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
To avoid incompatibility with recent dry-rb/hanami gems the dependencies
had to be updated.

- Added 'hanami-utils' to dependency
- Removed 'hanami' from dependency
- Added only the needed gems (hanami-model, hanami-controller,
  hanami-view, hanami-helpers) for specs as development dependencies.
- Removed syntactic shortcut to reference Hanami::Entity::Types

Signed-off-by: Vítor Avelino <contact@vitoravelino.me>